### PR TITLE
first pass at a maxReplicas property for deployment configs

### DIFF
--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -310,6 +310,9 @@ type DeploymentConfigSpec struct {
 	// Replicas is the number of desired replicas.
 	Replicas int32
 
+	//MaxReplicas is maximum number replicas can be set to.
+	MaxReplicas int32
+
 	// RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks.
 	// This field is a pointer to allow for differentiation between an explicit zero and not specified.
 	RevisionHistoryLimit *int32

--- a/pkg/deploy/cmd/scale_test.go
+++ b/pkg/deploy/cmd/scale_test.go
@@ -23,6 +23,7 @@ func TestScale(t *testing.T) {
 		size        uint
 		wait        bool
 		errExpected bool
+		maxReplicas uint
 	}{
 		{
 			name:        "simple scale",
@@ -36,6 +37,26 @@ func TestScale(t *testing.T) {
 			wait:        true,
 			errExpected: false,
 		},
+		{
+			name:        "scale with default max replicas",
+			size:        2,
+			errExpected: false,
+			wait:        false,
+		},
+		{
+			name:        "scale less than max replicas",
+			size:        2,
+			errExpected: false,
+			wait:        false,
+			maxReplicas: 2,
+		},
+		{
+			name:        "scale at max replicas",
+			size:        2,
+			errExpected: true,
+			wait:        false,
+			maxReplicas: 1,
+		},
 	}
 
 	for _, test := range tests {
@@ -46,6 +67,7 @@ func TestScale(t *testing.T) {
 
 		config := deploytest.OkDeploymentConfig(1)
 		config.Spec.Replicas = 1
+		config.Spec.MaxReplicas = int32(test.maxReplicas)
 		deployment, _ := deployutil.MakeDeployment(config, kapi.Codecs.LegacyCodec(deployapi.SchemeGroupVersion))
 
 		var wait *kubectl.RetryParams


### PR DESCRIPTION
This is a first pass at implementing a maxReplicas feature on the deployment config as referenced here:
https://trello.com/c/jH7MiGOg/374-rc-deployment-min-max-scale

Questions:
1) Not sure how to run just this test (go test?) I did a make test-unit
2) Had issues with the vagrant vm trying to pull images tagged rc1
3) Is this something that should be done via kubernetes first?
4) There may be more work to do around the UI using this value and greying out when max is reached
5) The oc client may be able to pre check this before it gets to the server.
